### PR TITLE
Rename project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,7 +98,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.12.0] - 2022-09-24
 ### Added
-- Server endpoints to support TOTP 2FA. See our [API documentation](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/AverageHelper/accountable-svelte/HEAD/server/openapi.yaml) for details.
+- Server endpoints to support TOTP 2FA. See our [API documentation](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/AverageHelper/recorded-finance/HEAD/server/openapi.yaml) for details.
 
 ### Changed
 - BREAKING: The server now requires the `AUTH_SECRET` environment variable to be set. This value should be randomly generated (perhaps using a [password generator](https://bitwarden.com/password-generator/)) and kept safe. This value lets the server sign JWTs and generate user secrets. See the [README](/server/README.md) for info.
@@ -114,7 +114,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.11.2] - 2022-09-09
 ### Added
-- Automated our release process and changelog handling. This changelog entry is a test that I only need to add an entry here for a release to be automatically deployed. The [Releases](https://github.com/AverageHelper/accountable-svelte/releases) view should automatically see this entry.
+- Automated our release process and changelog handling. This changelog entry is a test that I only need to add an entry here for a release to be automatically deployed. The [Releases](https://github.com/AverageHelper/recorded-finance/releases) view should automatically see this entry.
 
 ### Changed
 - Updated some CI/CD analysis tools.
@@ -153,7 +153,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.10.0] - 2022-08-05
 ### Changed
 - Ported front-end code from Vue to Svelte. It's [pretty cool](https://svelte.dev/).
-  - I want to experiment with Accountable under different front-end paradigms. So far, I've used [Flutter](https://github.com/AverageHelper/accountable-flutter), [Vue](https://github.com/AverageHelper/accountable-vue), and now [Svelte](https://github.com/AverageHelper/accountable-svelte). This version is the Svelte port.
+  - I want to experiment with Accountable under different front-end paradigms. So far, I've used [Flutter](https://github.com/AverageHelper/accountable-flutter), [Vue](https://github.com/AverageHelper/accountable-vue), and now [Svelte](https://github.com/AverageHelper/recorded-finance). This version is the Svelte port.
   - Svelte differs from Vue in that Svelte is a compiler, not a runtime. The bundled output contains only code needed for each component to work. There's no virtual DOM, but there's also no helpful front-end safety net.
   - Eventually, I plan to separate the back-end code from the front-end, so I'm not duplicating that part across several front-end repositories.
 
@@ -367,55 +367,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial commit
 
-[Unreleased]: https://github.com/AverageHelper/accountable-svelte/compare/v0.15.2...HEAD
-[0.15.2]: https://github.com/AverageHelper/accountable-svelte/compare/v0.15.1...v0.15.2
-[0.15.1]: https://github.com/AverageHelper/accountable-svelte/compare/v0.15.0...v0.15.1
-[0.15.0]: https://github.com/AverageHelper/accountable-svelte/compare/v0.14.6...v0.15.0
-[0.14.6]: https://github.com/AverageHelper/accountable-svelte/compare/v0.14.5...v0.14.6
-[0.14.5]: https://github.com/AverageHelper/accountable-svelte/compare/v0.14.4...v0.14.5
-[0.14.4]: https://github.com/AverageHelper/accountable-svelte/compare/v0.14.3...v0.14.4
-[0.14.3]: https://github.com/AverageHelper/accountable-svelte/compare/v0.14.2...v0.14.3
-[0.14.2]: https://github.com/AverageHelper/accountable-svelte/compare/v0.14.1...v0.14.2
-[0.14.1]: https://github.com/AverageHelper/accountable-svelte/compare/v0.14.0...v0.14.1
-[0.14.0]: https://github.com/AverageHelper/accountable-svelte/compare/v0.13.2...v0.14.0
-[0.13.2]: https://github.com/AverageHelper/accountable-svelte/compare/v0.13.1...v0.13.2
-[0.13.1]: https://github.com/AverageHelper/accountable-svelte/compare/v0.13.0...v0.13.1
-[0.13.0]: https://github.com/AverageHelper/accountable-svelte/compare/v0.12.0...v0.13.0
-[0.12.0]: https://github.com/AverageHelper/accountable-svelte/compare/v0.11.3...v0.12.0
-[0.11.3]: https://github.com/AverageHelper/accountable-svelte/compare/v0.11.2...v0.11.3
-[0.11.2]: https://github.com/AverageHelper/accountable-svelte/compare/v0.11.1...v0.11.2
-[0.11.1]: https://github.com/AverageHelper/accountable-svelte/compare/v0.11.0...v0.11.1
-[0.11.0]: https://github.com/AverageHelper/accountable-svelte/compare/v0.10.2...v0.11.0
-[0.10.2]: https://github.com/AverageHelper/accountable-svelte/compare/v0.10.1...v0.10.2
-[0.10.1]: https://github.com/AverageHelper/accountable-svelte/compare/v0.10.0...v0.10.1
-[0.10.0]: https://github.com/AverageHelper/accountable-svelte/compare/v0.9.1...v0.10.0
-[0.9.1]: https://github.com/AverageHelper/accountable-svelte/compare/v0.9.0...v0.9.1
-[0.9.0]: https://github.com/AverageHelper/accountable-svelte/compare/v0.8.1...v0.9.0
-[0.8.1]: https://github.com/AverageHelper/accountable-svelte/compare/v0.8.0...v0.8.1
-[0.8.0]: https://github.com/AverageHelper/accountable-svelte/compare/v0.7.0...v0.8.0
-[0.7.0]: https://github.com/AverageHelper/accountable-svelte/compare/v0.6.4...v0.7.0
-[0.6.4]: https://github.com/AverageHelper/accountable-svelte/compare/v0.6.3...v0.6.4
-[0.6.3]: https://github.com/AverageHelper/accountable-svelte/compare/v0.6.2...v0.6.3
-[0.6.2]: https://github.com/AverageHelper/accountable-svelte/compare/v0.6.1...v0.6.2
-[0.6.1]: https://github.com/AverageHelper/accountable-svelte/compare/v0.6.0...v0.6.1
-[0.6.0]: https://github.com/AverageHelper/accountable-svelte/compare/v0.5.7...v0.6.0
-[0.5.7]: https://github.com/AverageHelper/accountable-svelte/compare/v0.5.6...v0.5.7
-[0.5.6]: https://github.com/AverageHelper/accountable-svelte/compare/v0.5.5...v0.5.6
-[0.5.5]: https://github.com/AverageHelper/accountable-svelte/compare/v0.5.4...v0.5.5
-[0.5.4]: https://github.com/AverageHelper/accountable-svelte/compare/v0.5.3...v0.5.4
-[0.5.3]: https://github.com/AverageHelper/accountable-svelte/compare/v0.5.2...v0.5.3
-[0.5.2]: https://github.com/AverageHelper/accountable-svelte/compare/v0.5.1...v0.5.2
-[0.5.1]: https://github.com/AverageHelper/accountable-svelte/compare/v0.5.0...v0.5.1
-[0.5.0]: https://github.com/AverageHelper/accountable-svelte/compare/v0.4.3...v0.5.0
-[0.4.3]: https://github.com/AverageHelper/accountable-svelte/compare/v0.4.2...v0.4.3
-[0.4.2]: https://github.com/AverageHelper/accountable-svelte/compare/v0.4.1...v0.4.2
-[0.4.1]: https://github.com/AverageHelper/accountable-svelte/compare/v0.4.0...v0.4.1
-[0.4.0]: https://github.com/AverageHelper/accountable-svelte/compare/v0.3.4...v0.4.0
-[0.3.4]: https://github.com/AverageHelper/accountable-svelte/compare/v0.3.3...v0.3.4
-[0.3.3]: https://github.com/AverageHelper/accountable-svelte/compare/v0.3.2...v0.3.3
-[0.3.2]: https://github.com/AverageHelper/accountable-svelte/compare/v0.3.1...v0.3.2
-[0.3.1]: https://github.com/AverageHelper/accountable-svelte/compare/v0.3.0...v0.3.1
-[0.3.0]: https://github.com/AverageHelper/accountable-svelte/compare/v0.2.0...v0.3.0
-[0.2.0]: https://github.com/AverageHelper/accountable-svelte/compare/v0.1.0...v0.2.0
-[0.1.0]: https://github.com/AverageHelper/accountable-svelte/compare/v0.0.0...v0.1.0
-[0.0.0]: https://github.com/AverageHelper/accountable-svelte/releases/tag/v0.0.0
+[Unreleased]: https://github.com/AverageHelper/recorded-finance/compare/v0.15.2...HEAD
+[0.15.2]: https://github.com/AverageHelper/recorded-finance/compare/v0.15.1...v0.15.2
+[0.15.1]: https://github.com/AverageHelper/recorded-finance/compare/v0.15.0...v0.15.1
+[0.15.0]: https://github.com/AverageHelper/recorded-finance/compare/v0.14.6...v0.15.0
+[0.14.6]: https://github.com/AverageHelper/recorded-finance/compare/v0.14.5...v0.14.6
+[0.14.5]: https://github.com/AverageHelper/recorded-finance/compare/v0.14.4...v0.14.5
+[0.14.4]: https://github.com/AverageHelper/recorded-finance/compare/v0.14.3...v0.14.4
+[0.14.3]: https://github.com/AverageHelper/recorded-finance/compare/v0.14.2...v0.14.3
+[0.14.2]: https://github.com/AverageHelper/recorded-finance/compare/v0.14.1...v0.14.2
+[0.14.1]: https://github.com/AverageHelper/recorded-finance/compare/v0.14.0...v0.14.1
+[0.14.0]: https://github.com/AverageHelper/recorded-finance/compare/v0.13.2...v0.14.0
+[0.13.2]: https://github.com/AverageHelper/recorded-finance/compare/v0.13.1...v0.13.2
+[0.13.1]: https://github.com/AverageHelper/recorded-finance/compare/v0.13.0...v0.13.1
+[0.13.0]: https://github.com/AverageHelper/recorded-finance/compare/v0.12.0...v0.13.0
+[0.12.0]: https://github.com/AverageHelper/recorded-finance/compare/v0.11.3...v0.12.0
+[0.11.3]: https://github.com/AverageHelper/recorded-finance/compare/v0.11.2...v0.11.3
+[0.11.2]: https://github.com/AverageHelper/recorded-finance/compare/v0.11.1...v0.11.2
+[0.11.1]: https://github.com/AverageHelper/recorded-finance/compare/v0.11.0...v0.11.1
+[0.11.0]: https://github.com/AverageHelper/recorded-finance/compare/v0.10.2...v0.11.0
+[0.10.2]: https://github.com/AverageHelper/recorded-finance/compare/v0.10.1...v0.10.2
+[0.10.1]: https://github.com/AverageHelper/recorded-finance/compare/v0.10.0...v0.10.1
+[0.10.0]: https://github.com/AverageHelper/recorded-finance/compare/v0.9.1...v0.10.0
+[0.9.1]: https://github.com/AverageHelper/recorded-finance/compare/v0.9.0...v0.9.1
+[0.9.0]: https://github.com/AverageHelper/recorded-finance/compare/v0.8.1...v0.9.0
+[0.8.1]: https://github.com/AverageHelper/recorded-finance/compare/v0.8.0...v0.8.1
+[0.8.0]: https://github.com/AverageHelper/recorded-finance/compare/v0.7.0...v0.8.0
+[0.7.0]: https://github.com/AverageHelper/recorded-finance/compare/v0.6.4...v0.7.0
+[0.6.4]: https://github.com/AverageHelper/recorded-finance/compare/v0.6.3...v0.6.4
+[0.6.3]: https://github.com/AverageHelper/recorded-finance/compare/v0.6.2...v0.6.3
+[0.6.2]: https://github.com/AverageHelper/recorded-finance/compare/v0.6.1...v0.6.2
+[0.6.1]: https://github.com/AverageHelper/recorded-finance/compare/v0.6.0...v0.6.1
+[0.6.0]: https://github.com/AverageHelper/recorded-finance/compare/v0.5.7...v0.6.0
+[0.5.7]: https://github.com/AverageHelper/recorded-finance/compare/v0.5.6...v0.5.7
+[0.5.6]: https://github.com/AverageHelper/recorded-finance/compare/v0.5.5...v0.5.6
+[0.5.5]: https://github.com/AverageHelper/recorded-finance/compare/v0.5.4...v0.5.5
+[0.5.4]: https://github.com/AverageHelper/recorded-finance/compare/v0.5.3...v0.5.4
+[0.5.3]: https://github.com/AverageHelper/recorded-finance/compare/v0.5.2...v0.5.3
+[0.5.2]: https://github.com/AverageHelper/recorded-finance/compare/v0.5.1...v0.5.2
+[0.5.1]: https://github.com/AverageHelper/recorded-finance/compare/v0.5.0...v0.5.1
+[0.5.0]: https://github.com/AverageHelper/recorded-finance/compare/v0.4.3...v0.5.0
+[0.4.3]: https://github.com/AverageHelper/recorded-finance/compare/v0.4.2...v0.4.3
+[0.4.2]: https://github.com/AverageHelper/recorded-finance/compare/v0.4.1...v0.4.2
+[0.4.1]: https://github.com/AverageHelper/recorded-finance/compare/v0.4.0...v0.4.1
+[0.4.0]: https://github.com/AverageHelper/recorded-finance/compare/v0.3.4...v0.4.0
+[0.3.4]: https://github.com/AverageHelper/recorded-finance/compare/v0.3.3...v0.3.4
+[0.3.3]: https://github.com/AverageHelper/recorded-finance/compare/v0.3.2...v0.3.3
+[0.3.2]: https://github.com/AverageHelper/recorded-finance/compare/v0.3.1...v0.3.2
+[0.3.1]: https://github.com/AverageHelper/recorded-finance/compare/v0.3.0...v0.3.1
+[0.3.0]: https://github.com/AverageHelper/recorded-finance/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/AverageHelper/recorded-finance/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/AverageHelper/recorded-finance/compare/v0.0.0...v0.1.0
+[0.0.0]: https://github.com/AverageHelper/recorded-finance/releases/tag/v0.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
+- Renamed from 'Accountable' to 'Recorded Finance'. Hopefully we don't have to rename ourselves again soon!
 - Improved a11y scores on [webpagetest.org](https://www.webpagetest.org/).
 
 ## [0.15.2] - 2022-12-21

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ To create a translation for a language which we don't yet support:
 
 ## Issues
 
-[Issues](https://github.com/AverageHelper/accountable-svelte/issues/new/choose) are very valuable to this project.
+[Issues](https://github.com/AverageHelper/recorded-finance/issues/new/choose) are very valuable to this project.
 
 - Ideas are a valuable source of contributions others can make
 - Problems show where this project is lacking

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Accountable
+# Recorded Finance
 
-[![Language grade: JavaScript](https://img.shields.io/lgtm/grade/javascript/g/AverageHelper/accountable-svelte.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/AverageHelper/accountable-svelte/context:javascript) [![Total alerts](https://img.shields.io/lgtm/alerts/g/AverageHelper/accountable-svelte.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/AverageHelper/accountable-svelte/alerts/)
+[![Language grade: JavaScript](https://img.shields.io/lgtm/grade/javascript/g/AverageHelper/recorded-finance.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/AverageHelper/recorded-finance/context:javascript) [![Total alerts](https://img.shields.io/lgtm/alerts/g/AverageHelper/recorded-finance.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/AverageHelper/recorded-finance/alerts/)
 
 A Svelte app for managing monetary assets. All data is encrypted client-side and stored on a server that you control.
 
@@ -69,7 +69,7 @@ If you're hosting the Accountable server on the same machine that hosts the Acco
 Using `localhost` for this will cause clients to try _themselves_ as the Accountable server, and that's usually not what you want.
 
 ```sh
-$ cd accountable-svelte       # Be in the root directory
+$ cd recorded-finance       # Be in the root directory
 $ npm ci                      # Install dependencies
 $ npm run build:client:quick  # Compile the client
 $ npm run dev:client          # Start a local webserver
@@ -79,7 +79,7 @@ $ npm run dev:client          # Start a local webserver
 
 The webserver will print a URL in your terminal to paste into your browser. It should look something like [http://127.0.0.1:5173](http://127.0.0.1:5173). Give that a go, and you're off to the races!
 
-I recommend you deploy the client (the contents of the `accountable-svelte/dist` folder) on a webserver like [nginx](https://nginx.org/en/).
+I recommend you deploy the client (the contents of the `recorded-finance/dist` folder) on a webserver like [nginx](https://nginx.org/en/).
 
 DO NOT FORGET your Accountable ACCOUNT ID or PASSWORD. If you do, your data is irretrievably lost. You have been warned. :)
 
@@ -89,7 +89,7 @@ DO NOT FORGET your Accountable ACCOUNT ID or PASSWORD. If you do, your data is i
 
 ## Contributing
 
-This project is entirely open source. Do with it what you will. If you're willing to help me improve this project, consider [filing an issue](https://github.com/AverageHelper/accountable-svelte/issues/new/choose).
+This project is entirely open source. Do with it what you will. If you're willing to help me improve this project, consider [filing an issue](https://github.com/AverageHelper/recorded-finance/issues/new/choose).
 
 See [CONTRIBUTING.md](/CONTRIBUTING.md) for ways to contribute.
 
@@ -118,7 +118,7 @@ While our cookies indeed deal with the user's login "session," [GDPR.edu](https:
 
 ### How do releases work?
 
-The manual way is complicated: add a version entry to [CHANGELOG.md](/CHANGELOG.md), straighten out the not-yet-valid URLs in the changelog footer, update [package.json](/package.json) and [package-lock.json](/package-lock.json) (the latter using `npm i`), then merge the PR, then copy the changelog entry to cut a new [Release](https://github.com/AverageHelper/accountable-svelte/releases) and tag using GitHub's UI. The changelog's version links now point to the relevant newly-created tags.
+The manual way is complicated: add a version entry to [CHANGELOG.md](/CHANGELOG.md), straighten out the not-yet-valid URLs in the changelog footer, update [package.json](/package.json) and [package-lock.json](/package-lock.json) (the latter using `npm i`), then merge the PR, then copy the changelog entry to cut a new [Release](https://github.com/AverageHelper/recorded-finance/releases) and tag using GitHub's UI. The changelog's version links now point to the relevant newly-created tags.
 
 I've missed some steps before. For example, version [0.9.0](/CHANGELOG.md#090---2022-07-12) didn't originally have a tag, so related comparison links were broken. Not ideal. Since we use [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), we can automate most of our release steps, as follows:
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ There are many open-source balance keepers out there, but none I've found that I
 
 ### The Goal
 
-The aim of Accountable is to be cross-platform and portable. Eventually, I plan to have an Android client on the F-droid store, an iOS app on the App Store, and a website as well. The self-host option will always be available, and I intend for this project to always be open-source.
+The aim of this project is to be a cross-platform and portable place to keep personal financial records. There will always be a way to self-host the storage server, and I intend for this project to always be open-source.
 
 ## Setup
 
@@ -52,7 +52,7 @@ See [the server's README](/server/README.md) for info on that.
 # .env
 
 # Where your server lives (optional for Vercel, required with Express)
-VITE_ACCOUNTABLE_SERVER_URL={your Accountable backend URL}:40850
+VITE_PLATFORM_SERVER_URL={your storage server URL}:40850
 
 # Enables the "Login" menu item (optional, defaults to "true")
 VITE_ENABLE_LOGIN=true
@@ -64,9 +64,9 @@ VITE_ENABLE_SIGNUP=false
 VITE_PUBNUB_SUBSCRIBE_KEY={your subscribe key from PubNub}
 ```
 
-If you're hosting the Accountable server on the same machine that hosts the Accountable client, do NOT use `localhost` for the `VITE_ACCOUNTABLE_SERVER_URL`. You must set this to a URL that _clients_—that is, web browsers—can use to access your Accountable backend.
+If you're hosting the storage server on the same machine that hosts the Recorded Finance web client, do NOT use `localhost` for the `VITE_PLATFORM_SERVER_URL`. You must set this to a URL that _clients_—that is, web browsers—can use to access your back-end.
 
-Using `localhost` for this will cause clients to try _themselves_ as the Accountable server, and that's usually not what you want.
+Using `localhost` for this will cause clients to try _themselves_ as the storage server, and that's usually not what you want.
 
 ```sh
 $ cd recorded-finance       # Be in the root directory
@@ -81,7 +81,7 @@ The webserver will print a URL in your terminal to paste into your browser. It s
 
 I recommend you deploy the client (the contents of the `recorded-finance/dist` folder) on a webserver like [nginx](https://nginx.org/en/).
 
-DO NOT FORGET your Accountable ACCOUNT ID or PASSWORD. If you do, your data is irretrievably lost. You have been warned. :)
+DO NOT FORGET your ACCOUNT ID or PASSWORD. If you do, your data is irretrievably lost. That data is encrypted, and can only be retrieved using those details. You have been warned. :)
 
 ## Acknowledgements
 
@@ -99,14 +99,14 @@ Some questions I've asked myself while developing this. You might have these que
 
 ### Why use cookies?
 
-JavaScript is not a safe spot to store cookies. The nascent versions of Accountable's front-end client stored the user's login token in a JavaScript variable. I later learned a better way: don't handle the token myself, let the browser handle it with [standard cookie security APIs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#restrict_access_to_cookies).
+JavaScript is not a safe spot to store cookies. Nascent versions of our front-end client stored the user's login token in a JavaScript variable. I later learned a better way: don't handle the token myself, let the browser handle it with [standard cookie security APIs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#restrict_access_to_cookies).
 
-Accountable's back-end server still responds to successful login requests with the token in the response body, but the server also now asks requesting clients to set the token as a cookie with the following attributes:
+Our storage server still responds to successful login requests with the token in the response body, but the server also now asks requesting clients to set the token as a cookie with the following attributes:
 
 - `HttpOnly` - According to [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#restrict_access_to_cookies): "A cookie with the HttpOnly attribute is inaccessible to the JavaScript [`Document.cookie`](https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie) API; it's only sent to the server. For example, cookies that persist in server-side sessions _don't need to be available to JavaScript_ and should have the `HttpOnly` attribute. This precaution helps mitigate cross-site scripting ([XSS](<https://developer.mozilla.org/en-US/docs/Web/Security/Types_of_attacks#cross-site_scripting_(xss)>)) attacks." (emphasis mine)
 - `Secure` - Not set if the server is running on `localhost`. According to [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#restrict_access_to_cookies): "A cookie with the Secure attribute is only sent to the server with an encrypted request over the HTTPS protocol."
 
-If create your own Accountable client, please don't mishandle the token. If you dig back in our git history to find and use a version that uses the old JavaScript way, know that you may be getting into avoidable security vulnerabilities.
+If you create your own client to use against our hosted storage server, please don't mishandle the auth token. If you dig back in our git history to find and use a version that uses the old JavaScript-based auth method, know that you may be getting into avoidable security vulnerabilities.
 
 ### Why disclose cookies?
 
@@ -149,6 +149,6 @@ I have a long wishlist for this project. In no particular order:
 - API v1.
 - Detailed documentation webpage (protocols, API, etc.)
 - Standard API evolution protocol (deprecation and obsoleting of old API versions).
-- SDK for third-party tools to participate in Accountable's E2EE data access without needing to re-implement the protocols themselves against our API.
-- Figure out if we can use the name "Accountable" or whether we must change that.
+- SDK for third-party tools to participate in our hosted E2EE data access without needing to re-implement the correct protocols directly.
 - Logo.
+- Mobile apps?

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,9 +8,9 @@ project.
 
 ## Reporting a Bug
 
-Thank you for improving the security of Accountable!
+Thank you for improving the security of Recorded Finance!
 
-If you discover a security vulnerability in Accountable, please disclose it via [our huntr page](https://huntr.dev/repos/averagehelper/recorded-finance). Bounties, CVE assignment, response times, and past reports are all there, or will be there following the first report.
+If you discover a security vulnerability in Recorded Finance, please disclose it via [our huntr page](https://huntr.dev/repos/averagehelper/recorded-finance). Bounties, CVE assignment, response times, and past reports are all there, or will be there following the first report.
 
 Report security bugs in third-party modules to the person or team maintaining
 the module.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,7 +10,7 @@ project.
 
 Thank you for improving the security of Accountable!
 
-If you discover a security vulnerability in Accountable, please disclose it via [our huntr page](https://huntr.dev/repos/averagehelper/accountable-svelte). Bounties, CVE assignment, response times, and past reports are all there, or will be there following the first report.
+If you discover a security vulnerability in Accountable, please disclose it via [our huntr page](https://huntr.dev/repos/averagehelper/recorded-finance). Bounties, CVE assignment, response times, and past reports are all there, or will be there following the first report.
 
 Report security bugs in third-party modules to the person or team maintaining
 the module.

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="robots" content="noai" />
-		<title>Accountable</title>
+		<title>Recorded Finance</title>
 		<link rel="icon" href="/favicon.ico" />
 		<link rel="stylesheet" href="./node_modules/bootstrap/dist/css/bootstrap.min.css" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -51,7 +51,7 @@
 				<!-- JS removes this tag if JS is enabled! -->
 				<!-- TODO: Display as much as we can without JavaScript. Would SSR work? -->
 				<p
-					>I'm sorry but Accountable doesn't work without JavaScript enabled. (I know, it's
+					>I'm sorry but Recorded Finance doesn't work without JavaScript enabled. (I know, it's
 					silly.)</p
 				>
 				<p><strong>Please enable JavaScript to continue.</strong></p>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "accountable-svelte",
+	"name": "recorded-finance-client",
 	"version": "0.15.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "accountable-svelte",
+			"name": "recorded-finance-client",
 			"version": "0.15.2",
 			"license": "GPL-3.0",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "accountable-svelte",
+	"name": "recorded-finance-client",
 	"version": "0.15.2",
 	"license": "GPL-3.0",
 	"description": "A Svelte app for managing monetary assets.",

--- a/server/README.md
+++ b/server/README.md
@@ -1,4 +1,4 @@
-# Accountable Server
+# Recorded Finance Server
 
 The machine that stores stuff.
 
@@ -47,7 +47,7 @@ HOST={your frontend hostname, with protocol}
 MAX_USERS={the limit to the number of users allowed to register new accounts}
 # optional, defaults to 5
 
-MAX_BYTES={the total number of bytes that Accountable attachments are permitted to occupy on the system}
+MAX_BYTES={the total number of bytes that file attachments are permitted to occupy on the system}
 # optional, defaults to 20000000000 (20 GB)
 
 PUBNUB_PUBLISH_KEY={publish key given by PubNub}

--- a/server/README.md
+++ b/server/README.md
@@ -8,7 +8,7 @@ The machine that stores stuff.
 
 This server doesn't do much on its own once you're authenticated. You give it data, and you ask for that data back. If you want to encrypt that data, do that yourself before you send it.
 
-The API is documented using [OpenAPI](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/AverageHelper/accountable-svelte/main/server/openapi.yaml).
+The API is documented using [OpenAPI](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/AverageHelper/recorded-finance/main/server/openapi.yaml).
 
 ## Setup
 
@@ -63,7 +63,7 @@ PUBNUB_SECRET_KEY={secret key given by PubNub}
 Run these commands to compile and run
 
 ```sh
-$ cd accountable-svelte/server  # Be in the server directory (if you aren't already)
+$ cd recorded-finance/server  # Be in the server directory (if you aren't already)
 $ npm ci                     # Install dependencies
 $ npm run build              # Compile the server
 $ node .                     # Start the server in development mode
@@ -75,6 +75,6 @@ I recommend using something like [PM2](https://pm2.keymetrics.io) to run the ser
 
 ## Contributing
 
-This project is entirely open source. Do with it what you will. If you're willing to help me improve this project, consider [filing an issue](https://github.com/AverageHelper/accountable-svelte/issues/new/choose).
+This project is entirely open source. Do with it what you will. If you're willing to help me improve this project, consider [filing an issue](https://github.com/AverageHelper/recorded-finance/issues/new/choose).
 
 See [CONTRIBUTING.md](/CONTRIBUTING.md) for ways to contribute.

--- a/server/api/v0/version/index.ts
+++ b/server/api/v0/version/index.ts
@@ -2,7 +2,7 @@ import { apiHandler, dispatchRequests } from "../../../helpers/apiHandler";
 import { version } from "../../../version";
 
 export const GET = apiHandler("GET", (req, res) => {
-	res.json({ message: `Accountable v${version}`, version });
+	res.json({ message: `Recorded Finance v${version}`, version });
 });
 
 export default dispatchRequests({ GET });

--- a/server/auth/totp.test.ts
+++ b/server/auth/totp.test.ts
@@ -23,7 +23,7 @@ describe("TOTP", () => {
 	const accountId = "bob"; // doesn't matter much, just handy for the URI
 	const secret = base32Encode(Buffer.from("the user's special TOTP secret in plaintext"));
 	const secretUri = new URL(
-		`otpauth://totp/Accountable:${accountId}?algorithm=SHA1&digits=6&issuer=Accountable&period=30&secret=${secret}`
+		`otpauth://totp/RecordedFinance:${accountId}?algorithm=SHA1&digits=6&issuer=RecordedFinance&period=30&secret=${secret}`
 	);
 
 	test("secret generator throws if the seed is empty", () => {
@@ -68,13 +68,13 @@ describe("TOTP", () => {
 
 			expect(uri.protocol).toBe("otpauth:");
 			expect(uri.hostname).toBe("totp");
-			expect(uri.pathname).toBe(`/Accountable:${accountId}`);
+			expect(uri.pathname).toBe(`/RecordedFinance:${accountId}`);
 
 			const searchParams = uri.searchParams; // should have no more than the needed params
 			expect(Array.from(searchParams.keys())).toHaveLength(5);
 			expect(searchParams.get("algorithm")).toBe("SHA1");
 			expect(searchParams.get("digits")).toBe("6");
-			expect(searchParams.get("issuer")).toBe("Accountable");
+			expect(searchParams.get("issuer")).toBe("RecordedFinance");
 			expect(searchParams.get("period")).toBe("30");
 			expect(searchParams.get("secret")).toBe(secret);
 			// param order doesn't matter

--- a/server/auth/totp.ts
+++ b/server/auth/totp.ts
@@ -117,7 +117,7 @@ export function verifyTOTP(token: string, secretOrUri: string, options?: Verifie
 export function generateTOTPSecretURI(accountId: string, seed: string): string {
 	if (!accountId) throw new TypeError("accountId cannot be empty");
 
-	const issuer = "Accountable";
+	const issuer = "RecordedFinance";
 	const digits = 6; // number of digits
 	const period = 30; // seconds
 	const secret = generateSecret(seed);

--- a/server/ecosystem.config.json
+++ b/server/ecosystem.config.json
@@ -1,7 +1,7 @@
 {
 	"apps": [
 		{
-			"name": "accountable",
+			"name": "recorded-finance",
 			"script": "./dist/server.js",
 			"source_map_support": true,
 			"watch": ["dist"],

--- a/server/logger.ts
+++ b/server/logger.ts
@@ -27,7 +27,7 @@ interface BaseLogger {
 
 interface Logger extends BaseLogger {}
 
-const name = "Accountable";
+const name = "Recorded Finance";
 const baseLogger = bunyan.createLogger({ name, level: "debug" });
 
 /**

--- a/server/main.test.ts
+++ b/server/main.test.ts
@@ -40,7 +40,7 @@ describe("Routes", () => {
 				.get("/v0/version")
 				.expect("Content-Type", /json/u);
 			expect(response.status).toBe(200);
-			expect(response.body).toStrictEqual({ message: `Accountable v${version}`, version });
+			expect(response.body).toStrictEqual({ message: `Recorded Finance v${version}`, version });
 		});
 	});
 });

--- a/server/main.ts
+++ b/server/main.ts
@@ -39,5 +39,5 @@ app
 	});
 
 app.listen(PORT, () => {
-	logger.info(`Accountable storage server v${appVersion} listening on port ${PORT}`);
+	logger.info(`Recorded Finance storage server v${appVersion} listening on port ${PORT}`);
 });

--- a/server/openapi.yaml
+++ b/server/openapi.yaml
@@ -1,13 +1,13 @@
 openapi: 3.0.1
 info:
-  title: Accountable Server
+  title: Recorded Finance Auth/Storage Server
   version: 0.8.4
-  description: This is the Accountable Server. All the server does is store data given to it by the client. The server controls access to the data with basic password-based auth with optional time-based multi-factor auth. The Accountable client does most of the hard work of encrypting the user's data. You can read Accountable's source code on [GitHub](https://github.com/AverageHelper/recorded-finance).
+  description: This is the Recorded Finance Server. All the server does is store data given to it by the client. The server controls access to the data with basic password-based auth with optional time-based multi-factor auth. The Recorded Finance client does most of the hard work of encrypting the user's data. You can read Recorded Finance's source code on [GitHub](https://github.com/AverageHelper/recorded-finance).
   license:
     name: GNU General Public License v3.0
     url: https://github.com/AverageHelper/recorded-finance/blob/main/LICENSE
 externalDocs:
-  description: Find out more about Accountable
+  description: Find out more about Recorded Finance
   url: https://recorded.finance
 servers:
   - url: https://recorded.finance/api/
@@ -74,7 +74,7 @@ paths:
                     example: "0.3.0"
                   message:
                     type: string
-                    example: "Accountable v0.3.0"
+                    example: "Recorded Finance v0.3.0"
 
   "/v0/join":
     post:
@@ -1479,7 +1479,7 @@ components:
             - v0
             - v1
           default: v0
-          description: A string identifying the type of encryption used. Informs Accountable's client how to decrypt the data. The Accountable server does not care about this value, since it cannot decrypt the user's data anyway.
+          description: A string identifying the type of encryption used. Informs the client how to decrypt the data. The server does not care about this value, since it cannot decrypt the user's data anyway.
     Keys:
       type: object
       required:
@@ -1489,19 +1489,19 @@ components:
         dekMaterial:
           type: string
           maxLength: 65535
-          description: Encrypted data that the Accountable client uses to derive the user's Data Encryption Key. The Data Encryption Key is used to en/decrypt the ciphertext of documents. The Accountable server cannot decrypt this key, since it never receives the user's plaintext password. The Data Encryption Key should rarely change, but the `dekMaterial` may change often.
+          description: Encrypted data that the client uses to derive the user's Data Encryption Key. The Data Encryption Key is used to en/decrypt the ciphertext of documents. The server cannot decrypt this key, since it never receives the user's plaintext password. The Data Encryption Key should rarely change, but the `dekMaterial` may change often.
         passSalt:
           type: string
           maxLength: 191
-          description: The salt which the Accountable client used to generate the Password Key. The Password Key and the user's plaintext password are combined to decrypt the `dekMaterial` and retrieve the user's Data Encryption Key.
+          description: The salt which the client used to generate the Password Key. The Password Key and the user's plaintext password are combined to decrypt the `dekMaterial` and retrieve the user's Data Encryption Key.
         oldDekMaterial:
           type: string
           maxLength: 65535
-          description: The former `dekMaterial`. This value is used while changing the user's password, so the Accountable client has an opportunity to revert the password change if the user aborts the operation or something goes wrong.
+          description: The former `dekMaterial`. This value is used while changing the user's password, so the client has an opportunity to revert the password change if the user aborts the operation or something goes wrong.
         oldPassSalt:
           type: string
           maxLength: 191
-          description: The former `passSalt`. This value is used while changing the user's password, so the Accountable client has an opportunity to revert the password change if the user aborts the operation or something goes wrong.
+          description: The former `passSalt`. This value is used while changing the user's password, so the client has an opportunity to revert the password change if the user aborts the operation or something goes wrong.
     CollectionID:
       type: string
       enum:

--- a/server/openapi.yaml
+++ b/server/openapi.yaml
@@ -2,15 +2,15 @@ openapi: 3.0.1
 info:
   title: Accountable Server
   version: 0.8.4
-  description: This is the Accountable Server. All the server does is store data given to it by the client. The server controls access to the data with basic password-based auth with optional time-based multi-factor auth. The Accountable client does most of the hard work of encrypting the user's data. You can read Accountable's source code on [GitHub](https://github.com/AverageHelper/accountable-svelte).
+  description: This is the Accountable Server. All the server does is store data given to it by the client. The server controls access to the data with basic password-based auth with optional time-based multi-factor auth. The Accountable client does most of the hard work of encrypting the user's data. You can read Accountable's source code on [GitHub](https://github.com/AverageHelper/recorded-finance).
   license:
     name: GNU General Public License v3.0
-    url: https://github.com/AverageHelper/accountable-svelte/blob/main/LICENSE
+    url: https://github.com/AverageHelper/recorded-finance/blob/main/LICENSE
 externalDocs:
   description: Find out more about Accountable
-  url: https://accountable.average.name
+  url: https://recorded.finance
 servers:
-  - url: https://api.accountable.average.name
+  - url: https://recorded.finance/api/
 tags:
   - name: misc
     description: Make sure everything works

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "accountable-server",
+	"name": "recorded-finance-server",
 	"version": "0.8.5",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "accountable-server",
+			"name": "recorded-finance-server",
 			"version": "0.8.5",
 			"dependencies": {
 				"@prisma/client": "4.3.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "accountable-server",
+	"name": "recorded-finance-server",
 	"version": "0.8.5",
 	"scripts": {
 		"start": "./node_modules/.bin/vercel pull && npm run build:client && ./node_modules/.bin/concurrently -s first -kn VERCEL,APP \"npm run vercel:dev -- --color\" \"sleep 3 && npm run dev:client\"",

--- a/src/@types/env.d.ts
+++ b/src/@types/env.d.ts
@@ -1,6 +1,6 @@
 // See https://vitejs.dev/guide/env-and-mode.html
 interface ImportMetaEnv extends Readonly<Record<string, string>> {
-	readonly VITE_ACCOUNTABLE_SERVER_URL: string | undefined;
+	readonly VITE_PLATFORM_SERVER_URL: string | undefined;
 	readonly VITE_PUBNUB_SUBSCRIBE_KEY: string | undefined;
 	readonly VITE_ENABLE_SIGNUP: string | undefined;
 	readonly VITE_ENABLE_LOGIN: string | undefined;

--- a/src/About.svelte
+++ b/src/About.svelte
@@ -9,6 +9,8 @@
 		<h1 id="goals">{$_("about.goals.heading")}</h1>
 		<p>
 			<I18N keypath="about.goals.p1">
+				<!-- platform -->
+				<span>{$_("common.platform")}</span>
 				<!-- selfhost -->
 				<OutLink to="https://en.wikipedia.org/wiki/Self-hosting_(web_services)"
 					>{$_("about.goals.selfhost")}</OutLink
@@ -17,6 +19,10 @@
 				<OutLink to="https://en.wikipedia.org/wiki/Open-source_software"
 					>{$_("about.goals.opensource")}</OutLink
 				>
+				<!-- platform -->
+				<span>{$_("common.platform")}</span>
+				<!-- platform -->
+				<span>{$_("common.platform")}</span>
 			</I18N>
 		</p>
 	</section>
@@ -87,6 +93,7 @@
 	</section>
 	<!-- TODO: Reorganize. Mention https://www.budgetwithbuckets.com/ -->
 
+	<!-- TODO: Recorded Finance's Goal. Above mentions business model... what's ours? -->
 	<!-- TODO: About the "team" -->
 </main>
 

--- a/src/Home.svelte
+++ b/src/Home.svelte
@@ -54,6 +54,8 @@
 		<h3>{$_("home.encrypted.heading")}</h3>
 		<p>
 			<I18N keypath="home.encrypted.p1">
+				<!-- platform -->
+				<span>{$_("common.platform")}</span>
 				<!-- legal -->
 				<small>
 					<I18N keypath="home.encrypted.legal">

--- a/src/Install.svelte
+++ b/src/Install.svelte
@@ -16,6 +16,8 @@
 			<h1>{$_("install.service.heading")}</h1>
 			<p>
 				<I18N keypath="install.service.p1">
+					<!-- platform -->
+					<span>{$_("common.platform")}</span>
 					<!-- login -->
 					<Link to={loginRoute}>{$_("home.nav.log-in")}</Link>
 				</I18N>
@@ -29,9 +31,11 @@
 			<I18N keypath="install.self.p1">
 				<!-- readme -->
 				<OutLink to={repoReadmeHeading("setup")}>{$_("install.self.readme")}</OutLink>
+				<!-- platform -->
+				<span>{$_("common.platform")}</span>
 			</I18N>
 			{#if !isLoginEnabled}&nbsp;{$_("install.self.planning")}{/if}
 		</p>
-		<p>{$_("install.self.p2")}</p>
+		<p>{$_("install.self.p2", { values: { platform: $_("common.platform") } })}</p>
 	</section>
 </main>

--- a/src/Security.svelte
+++ b/src/Security.svelte
@@ -20,7 +20,11 @@
 
 	<!-- What kind of encryption? -->
 	<section>
-		<h2>{$_("security-faq.encryption-kind.question")}</h2>
+		<h2
+			>{$_("security-faq.encryption-kind.question", {
+				values: { platform: $_("common.platform") },
+			})}</h2
+		>
 		<p>
 			<I18N keypath="security-faq.encryption-kind.answer">
 				<!-- mge -->
@@ -37,10 +41,16 @@
 		<p>{$_("security-faq.where-keys.answer1")}</p>
 		<p>
 			<I18N keypath="security-faq.where-keys.answer2">
+				<!-- platform -->
+				<span>{$_("common.platform")}</span>
 				<!-- dek -->
 				<em>{$_("security-faq.where-keys.dek")}</em>
+				<!-- platform -->
+				<span>{$_("common.platform")}</span>
 				<!-- kek -->
 				<em>{$_("security-faq.where-keys.kek")}</em>
+				<!-- platform -->
+				<span>{$_("common.platform")}</span>
 			</I18N>
 		</p>
 		<p>
@@ -63,10 +73,20 @@
 
 	<!-- Auth: What about my password? -->
 	<section>
-		<h2>{$_("security-faq.passphrase-handling.question")}</h2>
-		<p>{$_("security-faq.passphrase-handling.answer1")}</p>
+		<h2
+			>{$_("security-faq.passphrase-handling.question", {
+				values: { platform: $_("common.platform") },
+			})}</h2
+		>
+		<p
+			>{$_("security-faq.passphrase-handling.answer1", {
+				values: { platform: $_("common.platform") },
+			})}</p
+		>
 		<p>
 			<I18N keypath="security-faq.passphrase-handling.answer2">
+				<!-- platform -->
+				<span>{$_("common.platform")}</span>
 				<!-- salts -->
 				<OutLink to="https://en.wikipedia.org/wiki/Salt_(cryptography)"
 					>{$_("security-faq.passphrase-handling.salts")}</OutLink
@@ -77,9 +97,15 @@
 				>
 			</I18N>
 		</p>
-		<p>{$_("security-faq.passphrase-handling.answer3")}</p>
+		<p
+			>{$_("security-faq.passphrase-handling.answer3", {
+				values: { platform: $_("common.platform") },
+			})}</p
+		>
 		<p>
 			<I18N keypath="security-faq.passphrase-handling.answer4">
+				<!-- platform -->
+				<span>{$_("common.platform")}</span>
 				<!-- dek -->
 				<em>{$_("security-faq.passphrase-handling.dek")}</em>
 			</I18N>
@@ -106,7 +132,11 @@
 	<section>
 		<h2>{$_("security-faq.change-passphrase.question")}</h2>
 		<p>{$_("security-faq.change-passphrase.answer1")}</p>
-		<p>{$_("security-faq.change-passphrase.answer2")}</p>
+		<p
+			>{$_("security-faq.change-passphrase.answer2", {
+				values: { platform: $_("common.platform") },
+			})}</p
+		>
 		<p>{$_("security-faq.change-passphrase.answer3")}</p>
 	</section>
 

--- a/src/components/Navbar.svelte
+++ b/src/components/Navbar.svelte
@@ -87,10 +87,9 @@
 				href={homeRoute}
 				class="navbar-brand"
 				role="heading"
-				aria-label={$_("common.platform")}
 				aria-level={1}
 				title={$_("common.platform")}
-				use:link>A&cent;countable</a
+				use:link>{$_("common.platform")}</a
 			>
 		{/if}
 	</aside>

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -6,7 +6,7 @@
 		"flag": "🇺🇸"
 	},
 	"common": {
-		"platform": "Accountable",
+		"platform": "Recorded Finance",
 		"cancel": "Cancel",
 		"application": "Client",
 		"current-language": "Current Language: {name}",
@@ -248,7 +248,7 @@
 			},
 			"meta": {
 				"heading": "Export",
-				"description": "Exports an {unencrypted} copy of all your data in JSON format. (Except attachments of course, those will come as Accountable got them).",
+				"description": "Exports an {unencrypted} copy of all your data in JSON format. (Except attachments of course, those will come as {platform} got them).",
 				"unencrypted": "unencrypted"
 			}
 		},
@@ -273,7 +273,7 @@
 		},
 		"location": {
 			"heading": "Location Service",
-			"api-disclaimer": "By default, we don't talk to any external location APIs. However, if you want Accountable to prefill transaction location fields, you'll need to select a different option below.",
+			"api-disclaimer": "By default, we don't talk to any external location APIs. However, if you want {platform} to prefill transaction location fields, you'll need to select a different option below.",
 			"iplocate": "IPLocate",
 			"manual-disclaimer": "Note that we have no \"automatic\" location features. We only fetch your current location when you press a button to request it. We use the {iplocate} API to obtain vague location data.",
 			"actions": {
@@ -425,13 +425,13 @@
 		},
 		"encrypted": {
 			"heading": "Your Ledger, Not Mine.",
-			"p1": "Accountable, by design, cannot see your data, even on our own servers. We don't need or want to see what you do with your money. That's not my job. {legal}",
+			"p1": "{platform}, by design, cannot see your data, even on our own servers. We don't need or want to see what you do with your money. That's not my job. {legal}",
 			"legal": "(I'd rather you {not} do illegal stuff with this.)",
 			"not": "not"
 		},
 		"open-source": {
 			"heading": "Keep Me Accountable.",
-			"open": "All of Accountable's source code is open to read.",
+			"open": "All of our source code is open to read.",
 			"pr": "Feel free to {issue} or submit a pull request on this project's {github}.",
 			"issue": "open an issue",
 			"github": "GitHub page",
@@ -501,20 +501,20 @@
 	"install": {
 		"service": {
 			"heading": "Hosted Service",
-			"p1": "There's an Accountable client-server architecture right here! Click the {login} link above to create an account."
+			"p1": "There's a hosted {platform} client-server architecture right here! Click the {login} link above to create an account."
 		},
 		"self": {
 			"heading": "Self-host Server",
-			"p1": "Check out the {readme} for more on how to set Accountable up on your own computer.",
+			"p1": "Check out the {readme} for more on how to set {platform} up on your own computer.",
 			"planning": "We're planning a hosted solution right here soon.",
-			"p2": "I'm toying with the idea of (optionally) using Firebase as an Accountable server. This would be great for users who are okay with using a Google service and don't want to pay to host their own installation.",
+			"p2": "I'm toying with the idea of (optionally) using Firebase as a {platform} storage server. This would be great for users who are okay with using a Google service and don't want to pay to host their own installation.",
 			"readme": "README"
 		}
 	},
 	"about": {
 		"goals": {
 			"heading": "Goals",
-			"p1": "The aim of Accountable is to be a cross-platform and portable spot to keep your transaction records and receipts. I plan to have proper mobile clients eventually. The {selfhost} option will always be available, and I intend for this project to always be {opensource}. You will always have access to the financial records that you give to Accountable, and Accountable cannot share those records with anyone else.",
+			"p1": "The aim of {platform} is to be a cross-platform and portable spot to keep your transaction records and receipts. I plan to have proper mobile clients eventually. The {selfhost} option will always be available, and I intend for this project to always be {opensource}. You will always have access to the financial records that you give to {platform}, and {platform} cannot share those records with anyone else.",
 			"selfhost": "self-host",
 			"opensource": "open-source"
 		},
@@ -547,14 +547,14 @@
 		"summary": "{tldr} Your data is unreadable by anyone but you (as far as I know.)",
 		"tldr": "TL;DR",
 		"encryption-kind": {
-			"question": "What sort of encryption does Accountable do?",
+			"question": "What sort of encryption does {platform} do?",
 			"answer": "We use only the best {mge} everyone else uses.",
 			"mge": "\"military-grade encryption\""
 		},
 		"where-keys": {
 			"question": "Who holds the encryption keys?",
 			"answer1": "You do.",
-			"answer2": "When you create an account, Accountable generates a data-encryption key {dek} to use to encrypt and decrypt your data. Accountable generates a separate key-encryption key {kek} from your given passphrase to use to encrypt your DEK. Accountable sends the encrypted DEK blob to our servers to store. This encrypted blob is useless without the KEK to decrypt it, and your KEK is unknown without your passphrase.",
+			"answer2": "When you create an account, {platform} generates a data-encryption key {dek} to use to encrypt and decrypt your data. {platform} generates a separate key-encryption key {kek} from your given passphrase to use to encrypt your DEK. {platform} sends the encrypted DEK blob to our servers to store. This encrypted blob is useless without the KEK to decrypt it, and your KEK is unknown without your passphrase.",
 			"dek": "(DEK)",
 			"kek": "(KEK)",
 			"answer3": "We use {sha512} and {pbkdf2} with 10,000 rounds to generate these keys. See {source}.",
@@ -563,13 +563,13 @@
 			"source": "the relevant source code"
 		},
 		"passphrase-handling": {
-			"question": "What does Accountable do with my passphrase?",
-			"answer1": "Accountable never transmits your passphrase anywhere, even over TLS.",
-			"answer2": "Accountable generates a one-way hash of your passphrase, and sends that instead. The server then {salts} and {hashes} that hash, and stores the resulting mash. (That mash has nothing to do with how your data is encrypted; see above.)",
+			"question": "What does {platform} do with my passphrase?",
+			"answer1": "{platform} never transmits your passphrase anywhere, even over TLS.",
+			"answer2": "{platform} generates a one-way hash of your passphrase, and sends that instead. The server then {salts} and {hashes} that hash, and stores the resulting mash. (That mash has nothing to do with how your data is encrypted; see above.)",
 			"salts": "salts",
 			"hashes": "hashes",
-			"answer3": "When you log in again, Accountable repeats the procedure on your hashed passphrase, and checks to see whether this new mash matches the stored mash.",
-			"answer4": "This mash is what Accountable's server uses to guard access to your encrypted database. If someone can give the server a passphrase hash that results in the correct mash, the server assumes that person is you, and happily sends over your encrypted data. No part of this mash—the hash the server gets, the salt the server generates, or the final mash of the two—can be used to decrypt your data. (Accountable uses your {dek} for that; see above.)",
+			"answer3": "When you log in again, {platform} repeats the procedure on your hashed passphrase, and checks to see whether this new mash matches the stored mash.",
+			"answer4": "This mash is what our storage server uses to guard access to your encrypted database. If someone can give the server a passphrase hash that results in the correct mash, the server assumes that person is you, and happily sends over your encrypted data. No part of this mash—the hash the server gets, the salt the server generates, or the final mash of the two—can be used to decrypt your data. ({platform} uses your {dek} for that; see above.)",
 			"dek": "DEK",
 			"answer5": "We use {sha512} and {bcrypt} with a cost factor of 15. See {source}.",
 			"sha512": "SHA-512",
@@ -579,7 +579,7 @@
 		"change-passphrase": {
 			"question": "What if I change my passphrase?",
 			"answer1": "We don't re-encrypt the entire database, if that's what you're thinking.",
-			"answer2": "Since your passphrase is only used to generate a KEK, Accountable only re-encrypts the DEK using the new KEK that your new passphrase generates.",
+			"answer2": "Since your passphrase is only used to generate a KEK, {platform} only re-encrypts the DEK using the new KEK that your new passphrase generates.",
 			"answer3": "If you think your DEK may be compromised, I'm sorry. You may export your data, delete your old account, create a new account, and import your data again. This will re-encrypt everything using a fresh DEK."
 		},
 		"lost-passphrase": {
@@ -589,7 +589,7 @@
 		},
 		"database-breach": {
 			"question": "What happens if someone steals the database?",
-			"answer1": "If your passphrase is long and complicated, there's nothing that anyone can do with Accountable's database. The server never sees your DEK, your passphrase's KEK, or your passphrase. None of those are in the database."
+			"answer1": "If your passphrase is long and complicated, there's nothing that anyone can do with our database. The server never sees your DEK, your passphrase's KEK, or your passphrase. None of those are in the database."
 		}
 	}
 }

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -6,7 +6,7 @@
 		"flag": "🇧🇷"
 	},
 	"common": {
-		"platform": "Accountable",
+		"platform": "Recorded Finance",
 		"cancel": "Cancelar",
 		"application": "Aplicativo",
 		"current-language": "Idioma Atual: {name}",
@@ -248,7 +248,7 @@
 			},
 			"meta": {
 				"heading": "Exportar",
-				"description": "Exporta uma cópia {unencrypted} de todos os seus dados no formato JSON. (Exceto os anexos, é claro, eles virão como o Accountable os recebeu).",
+				"description": "Exporta uma cópia {unencrypted} de todos os seus dados no formato JSON. (Exceto os anexos, é claro, eles virão como o {platform} os recebeu).",
 				"unencrypted": "não criptografada"
 			}
 		},
@@ -273,7 +273,7 @@
 		},
 		"location": {
 			"heading": "Servico de Localização",
-			"api-disclaimer": "Por padrão, não nos comunicamos com nenhuma API de localização externa. No entanto, se você quiser que Accountable preencha os campos de localização da transação automaticamente, será necessário selecionar uma opção diferente abaixo.",
+			"api-disclaimer": "Por padrão, não nos comunicamos com nenhuma API de localização externa. No entanto, se você quiser que {platform} preencha os campos de localização da transação automaticamente, será necessário selecionar uma opção diferente abaixo.",
 			"iplocate": "IPLocate",
 			"manual-disclaimer": "Observe que não temos recursos de localização \"automáticos\". Nós apenas buscamos sua localização atual quando você pressiona um botão para solicitá-la. Usamos a API {iplocate} para obter dados de localização vagos.",
 			"actions": {
@@ -425,13 +425,13 @@
 		},
 		"encrypted": {
 			"heading": "Seu Livro-razão De Dinheiro, Não O Meu.",
-			"p1": "Accountable, por projeto, não pode ver seus dados, mesmo em nossos próprios servidores. Não precisamos nem queremos ver o que você faz com seu dinheiro. Esse não é o meu trabalho. {legal}",
+			"p1": "{platform}, por projeto, não pode ver seus dados, mesmo em nossos próprios servidores. Não precisamos nem queremos ver o que você faz com seu dinheiro. Esse não é o meu trabalho. {legal}",
 			"legal": "(Prefiro que você {not} faça coisas ilegais com ele.)",
 			"not": "não"
 		},
 		"open-source": {
 			"heading": "Mantenha-me Responsável.",
-			"open": "Todo o código-fonte do Accountable está aberto para leitura.",
+			"open": "Todo o nosso código-fonte está aberto para leitura.",
 			"pr": "Fique a vontade para {issue} ou envie um pull request no {github} deste projeto.",
 			"issue": "abra um problema",
 			"github": "página do GitHub",
@@ -501,20 +501,20 @@
 	"install": {
 		"service": {
 			"heading": "Serviço Hospedado",
-			"p1": "Há uma arquitetura cliente-servidor Accountable aqui! Clique no link de {login} acima para criar uma conta."
+			"p1": "Há uma arquitetura cliente-servidor {platform} hospedou aqui! Clique no link de {login} acima para criar uma conta."
 		},
 		"self": {
 			"heading": "Servidor Auto-hospedado",
-			"p1": "Confira o {readme} para saber mais sobre como configurar o Accountable em seu próprio computador.",
+			"p1": "Confira o {readme} para saber mais sobre como configurar o {platform} em seu próprio computador.",
 			"planning": "Estamos planejando uma solução hospedada aqui em breve.",
-			"p2": "Estou pensando em (opcionalmente) usar o Firebase como um servidor Accountable. Isso seria ótimo para usuários que aceitam usar um serviço do Google e não desejam pagar para hospedar sua própria instalação.",
+			"p2": "Estou pensando em (opcionalmente) usar o Firebase como um servidor de armazenamento {platform}. Isso seria ótimo para usuários que aceitam usar um serviço do Google e não desejam pagar para hospedar sua própria instalação.",
 			"readme": "README"
 		}
 	},
 	"about": {
 		"goals": {
 			"heading": "Metas",
-			"p1": "O objetivo do Accountable é ser um ponto portátil e multiplataforma para manter seus registros e recibos de transações. Eu pretendo ter clientes móveis adequados eventualmente. A opção de {selfhost} estará sempre disponível, e pretendo que este projeto seja sempre de {opensource}. Você sempre terá acesso aos registros financeiros que fornecer ao Accountable, e o Accountable não pode compartilhar esses registros com mais ninguém.",
+			"p1": "O objetivo do {platform} é ser um ponto portátil e multiplataforma para manter seus registros e recibos de transações. Eu pretendo ter clientes móveis adequados eventualmente. A opção de {selfhost} estará sempre disponível, e pretendo que este projeto seja sempre de {opensource}. Você sempre terá acesso aos registros financeiros que fornecer ao {platform}, e o {platform} não pode compartilhar esses registros com mais ninguém.",
 			"selfhost": "auto-hospedagem",
 			"opensource": "código aberto"
 		},
@@ -547,14 +547,14 @@
 		"summary": "{tldr} Seus dados são ilegíveis por qualquer pessoa, exceto você (até onde sei.)",
 		"tldr": "Em resumo:",
 		"encryption-kind": {
-			"question": "Que tipo de criptografia Accountable faz?",
+			"question": "Que tipo de criptografia {platform} faz?",
 			"answer": "Usamos apenas o melhor {mge} como todos os outros.",
 			"mge": "\"criptografia de nível militar\""
 		},
 		"where-keys": {
 			"question": "Quem detém as chaves de criptografia?",
 			"answer1": "Você faz.",
-			"answer2": "Quando você cria uma conta, o Accountable gera uma chave de criptografia de dados {dek} a ser usada para criptografar e descriptografar seus dados. Accountable gera uma chave de criptografia de chave separada {kek} de sua senha fornecida para usar para criptografar seu DEK. Accountable envia o blob DEK criptografado para nossos servidores para armazenamento.Esse blob criptografado é inútil sem a KEK para descriptografá-lo e sua KEK é desconhecida sem sua senha.",
+			"answer2": "Quando você cria uma conta, o {platform} gera uma chave de criptografia de dados {dek} a ser usada para criptografar e descriptografar seus dados. {platform} gera uma chave de criptografia de chave separada {kek} de sua senha fornecida para usar para criptografar seu DEK. {platform} envia o blob DEK criptografado para nossos servidores para armazenamento.Esse blob criptografado é inútil sem a KEK para descriptografá-lo e sua KEK é desconhecida sem sua senha.",
 			"dek": "(DEK)",
 			"kek": "(KEK)",
 			"answer3": "Usamos {sha512} e {pbkdf2} com 10.000 rodadas para gerar essas chaves. Veja {source}.",
@@ -563,13 +563,13 @@
 			"source": "o código-fonte relevante"
 		},
 		"passphrase-handling": {
-			"question": "O que o Accountable faz com minha senha?",
-			"answer1": "Accountable nunca transmite sua senha em qualquer lugar, mesmo por TLS.",
-			"answer2": "Accountable gera um cerquilha unidirecional de sua frase secreta e o envia em seu lugar. O servidor então {salts} e {hashes} desse cerquilha, e armazena o mingau resultante. (Esse mingau não tem nada a ver com a forma como seus dados são criptografados; veja acima..)",
+			"question": "O que o {platform} faz com minha senha?",
+			"answer1": "{platform} nunca transmite sua senha em qualquer lugar, mesmo por TLS.",
+			"answer2": "{platform} gera um cerquilha unidirecional de sua frase secreta e o envia em seu lugar. O servidor então {salts} e {hashes} desse cerquilha, e armazena o mingau resultante. (Esse mingau não tem nada a ver com a forma como seus dados são criptografados; veja acima..)",
 			"salts": "salga",
 			"hashes": "faz cerquilha",
-			"answer3": "Quando você fizer login novamente, o Accountable tentará novamente com sua senha com cerquilha e verificará se esse novo mingau corresponde ao mingau armazenado.",
-			"answer4": "Esse mingau é o que o servidor do Accountable usa para proteger o acesso ao seu banco de dados criptografado. Se alguém puder fornecer ao servidor um cerquilha de senha que resulte no mingau correto, o servidor assumirá que essa pessoa é você e enviará alegremente seus dados criptografados. Nenhuma parte deste mingau—o cerquilha que o servidor obtém, o sal que o servidor gera ou o mingau final deles—pode ser usada para descriptografar seus dados. (Accountable usa seu {dek} para isso; veja acima.)",
+			"answer3": "Quando você fizer login novamente, o {platform} tentará novamente com sua senha com cerquilha e verificará se esse novo mingau corresponde ao mingau armazenado.",
+			"answer4": "Esse mingau é o que o servidor de armazenamento usa para proteger o acesso ao seu banco de dados criptografado. Se alguém puder fornecer ao servidor um cerquilha de senha que resulte no mingau correto, o servidor assumirá que essa pessoa é você e enviará alegremente seus dados criptografados. Nenhuma parte deste mingau—o cerquilha que o servidor obtém, o sal que o servidor gera ou o mingau final deles—pode ser usada para descriptografar seus dados. ({platform} usa seu {dek} para isso; veja acima.)",
 			"dek": "DEK",
 			"answer5": "Usamos {sha512} e {bcrypt} com um fator de custo de 15. Veja {source}.",
 			"sha512": "SHA-512",
@@ -579,7 +579,7 @@
 		"change-passphrase": {
 			"question": "E se eu mudar minha senha?",
 			"answer1": "Não criptografamos novamente todo o banco de dados, se é isso que você está pensando.",
-			"answer2": "Como sua frase secreta é usada apenas para gerar uma KEK, o Accountable criptografa novamente a DEK usando a nova KEK gerada por sua nova frase secreta.",
+			"answer2": "Como sua frase secreta é usada apenas para gerar uma KEK, o {platform} criptografa novamente a DEK usando a nova KEK gerada por sua nova frase secreta.",
 			"answer3": "Se você acha que seu DEK pode estar comprometido, sinto muito. Você pode exportar seus dados, excluir sua conta antiga, criar uma nova conta, e importar seus dados novamente. Isso criptografará tudo novamente usando um novo DEK."
 		},
 		"lost-passphrase": {
@@ -589,7 +589,7 @@
 		},
 		"database-breach": {
 			"question": "O que acontece se alguém roubar o banco de dados?",
-			"answer1": "Se sua senha for longa e complicada, não há nada que alguém possa fazer com o banco de dados do Accountable. O servidor nunca vê sua DEK, a KEK de sua frase secreta, ou sua frase secreta. Nenhum deles está no banco de dados."
+			"answer1": "Se sua senha for longa e complicada, não há nada que alguém possa fazer com o nosso banco de dados. O servidor nunca vê sua DEK, a KEK de sua frase secreta, ou sua frase secreta. Nenhum deles está no banco de dados."
 		}
 	}
 }

--- a/src/pages/auth/Locked.svelte
+++ b/src/pages/auth/Locked.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { _ } from "../../i18n";
-	import { AccountableError, NetworkError } from "../../transport/errors";
 	import { accountsPath } from "../../router";
+	import { NetworkError, PlatformError } from "../../transport/errors";
 	import { onMount, tick } from "svelte";
 	import { useNavigate } from "svelte-navigator";
 	import ActionButton from "../../components/buttons/ActionButton.svelte";
@@ -69,7 +69,7 @@
 			if (
 				(error instanceof NetworkError && error.code === "missing-mfa-credentials") ||
 				(error instanceof NetworkError && error.code === "missing-token") ||
-				(error instanceof AccountableError && error.code === "auth/unauthenticated")
+				(error instanceof PlatformError && error.code === "auth/unauthenticated")
 			) {
 				// Switch to TOTP mode
 				needsTotp = true;

--- a/src/pages/auth/Login.svelte
+++ b/src/pages/auth/Login.svelte
@@ -2,8 +2,8 @@
 	import { _ } from "../../i18n";
 	import { accountsPath, loginPath, signupPath } from "../../router";
 	import { onMount, tick } from "svelte";
+	import { PlatformError, UnreachableCaseError } from "../../transport/errors";
 	import { repoReadmeHeading } from "../../platformMeta";
-	import { AccountableError, UnreachableCaseError } from "../../transport/errors";
 	import { useLocation, useNavigate } from "svelte-navigator";
 	import ActionButton from "../../components/buttons/ActionButton.svelte";
 	import ErrorNotice from "../../components/ErrorNotice.svelte";
@@ -164,7 +164,7 @@
 			navigate(accountsPath(), { replace: true });
 		} catch (error) {
 			// FIXME: Better semantics here:
-			if (error instanceof AccountableError && error.code === "auth/unauthenticated") {
+			if (error instanceof PlatformError && error.code === "auth/unauthenticated") {
 				// Switch to TOTP mode
 				needsTotp = true;
 				console.debug(`Entering ${mode} mode`);

--- a/src/pages/settings/Exports.svelte
+++ b/src/pages/settings/Exports.svelte
@@ -14,7 +14,7 @@
 
 		try {
 			const dataUri = await compressUserData(shouldMinify);
-			downloadFileAtUrl(dataUri, "accountable.zip");
+			downloadFileAtUrl(dataUri, "recorded-finance.zip");
 		} catch (error) {
 			handleError(error);
 		} finally {
@@ -29,6 +29,8 @@
 		<I18N keypath="settings.export.meta.description">
 			<!-- unencrypted -->
 			<strong>{$_("settings.export.meta.unencrypted")}</strong>
+			<!-- platform -->
+			<span>{$_("common.platform")}</span>
 		</I18N>
 	</p>
 	<!-- <p

--- a/src/pages/settings/Import.svelte
+++ b/src/pages/settings/Import.svelte
@@ -53,7 +53,7 @@
 				},
 			});
 
-			const expectedDbName = "accountable/database.json";
+			const expectedDbName = "recorded-finance/database.json";
 			const dbFile = zipFile.find(f => f.filename === expectedDbName);
 			if (!dbFile?.getData)
 				throw new TypeError(

--- a/src/pages/settings/LocationPrefForm.svelte
+++ b/src/pages/settings/LocationPrefForm.svelte
@@ -57,7 +57,7 @@
 
 <Form on:submit={submitNewLocationPref}>
 	<h3>{$_("settings.location.heading")}</h3>
-	<p>{$_("settings.location.api-disclaimer")}</p>
+	<p>{$_("settings.location.api-disclaimer", { values: { platform: $_("common.platform") } })}</p>
 
 	<div class="options">
 		{#each sensitivityOptions as option}

--- a/src/pages/settings/MfaEnrollModal.svelte
+++ b/src/pages/settings/MfaEnrollModal.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { _ } from "../../i18n";
-	import { AccountableError } from "../../transport/errors";
 	import { createEventDispatcher, onMount } from "svelte";
+	import { PlatformError } from "../../transport/errors";
 	import ActionButton from "../../components/buttons/ActionButton.svelte";
 	import Modal from "../../components/Modal.svelte";
 	import TextField from "../../components/inputs/TextField.svelte";
@@ -53,7 +53,7 @@
 		// Must already be logged in
 		const accountId = $currentUser?.accountId;
 		if (accountId === undefined) {
-			handleError(new AccountableError("auth/unauthenticated"));
+			handleError(new PlatformError("auth/unauthenticated"));
 			return;
 		}
 
@@ -78,7 +78,7 @@
 
 		// Must have already retrieved a secret
 		if (totpSecrets === null) {
-			handleError(new AccountableError("auth/unauthenticated"));
+			handleError(new PlatformError("auth/unauthenticated"));
 			return;
 		}
 

--- a/src/platformMeta.ts
+++ b/src/platformMeta.ts
@@ -1,7 +1,7 @@
 import { version } from "./version";
 
 /** Accountable's repo homepage. */
-export const repoMain = "https://github.com/AverageHelper/accountable-svelte";
+export const repoMain = "https://github.com/AverageHelper/recorded-finance";
 
 /** Accountable's homepage for filing new issues. */
 export const repoNewIssue = `${repoMain}/issues/new/choose` as const;
@@ -15,7 +15,7 @@ export const repo = `${repoMain}/tree/v${version}` as const;
  * @example
  * ```ts
  * repoReadmeHeading("why-use-cookies")
- * // Returns "https://github.com/AverageHelper/accountable-svelte/tree/v10.0.1/README.md#why-use-cookies"
+ * // Returns "https://github.com/AverageHelper/recorded-finance/tree/v10.0.1/README.md#why-use-cookies"
  * ```
  */
 export function repoReadmeHeading<H extends string>(
@@ -30,7 +30,7 @@ export function repoReadmeHeading<H extends string>(
  * @example
  * ```ts
  * repoFile("LICENSE")
- * // Returns "https://github.com/AverageHelper/accountable-svelte/tree/v10.0.1/LICENSE"
+ * // Returns "https://github.com/AverageHelper/recorded-finance/tree/v10.0.1/LICENSE"
  * ```
  */
 export function repoFile<P extends string>(path: P): `${typeof repo}/${typeof path}` {

--- a/src/platformMeta.ts
+++ b/src/platformMeta.ts
@@ -1,12 +1,12 @@
 import { version } from "./version";
 
-/** Accountable's repo homepage. */
+/** Recorded Finance's repo homepage. */
 export const repoMain = "https://github.com/AverageHelper/recorded-finance";
 
-/** Accountable's homepage for filing new issues. */
+/** Recorded Finance's homepage for filing new issues. */
 export const repoNewIssue = `${repoMain}/issues/new/choose` as const;
 
-/** Accountable's repo URL for the current version tag. */
+/** Recorded Finance's repo URL for the current version tag. */
 export const repo = `${repoMain}/tree/v${version}` as const;
 
 /**

--- a/src/store/attachmentsStore.ts
+++ b/src/store/attachmentsStore.ts
@@ -230,9 +230,9 @@ export async function importAttachment(
 ): Promise<void> {
 	const storedAttachment = get(attachments)[attachmentToImport.id];
 
-	const path = `accountable/storage/${attachmentToImport.storagePath.split(".")[0] as string}/${
-		attachmentToImport.title
-	}`;
+	const path = `recorded-finance/storage/${
+		attachmentToImport.storagePath.split(".")[0] as string
+	}/${attachmentToImport.title}`;
 	const fileRef = zip?.find(f => f.filename === path) ?? null;
 	if (!fileRef?.getData) {
 		logger.warn(`No file found in zip with path ${path}`);

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -1,7 +1,7 @@
-import { AccountableError, NetworkError } from "../transport/errors/index.js";
-import { getServerVersion } from "../transport/server.js";
 import { derived, get, writable } from "svelte/store";
+import { getServerVersion } from "../transport/server.js";
 import { logger } from "../logger.js";
+import { NetworkError, PlatformError } from "../transport/errors/index.js";
 import { StructError } from "superstruct";
 import { t } from "../i18n.js";
 import { toast } from "@zerodevx/svelte-toast";
@@ -93,7 +93,7 @@ export async function loadServerVersion(): Promise<void> {
 
 export function handleError(error: unknown): void {
 	let message: string;
-	if (error instanceof AccountableError) {
+	if (error instanceof PlatformError) {
 		message = error.code;
 	} else if (error instanceof StructError) {
 		message = `ValidationError: ${error.message}`;

--- a/src/transport/apiStruts.ts
+++ b/src/transport/apiStruts.ts
@@ -1,5 +1,5 @@
-import type { AccountableDB } from "./db";
 import type { CollectionId } from "./api";
+import type { PlatformDB } from "./db";
 import type { RawServerResponse } from "./schemas.js";
 import type { RequestOpts } from "oazapfts/lib/runtime";
 import { assertRawServerResponse } from "./schemas.js";
@@ -32,7 +32,7 @@ interface APIResponse {
  */
 export async function run<A extends Array<unknown>>(
 	r: APIRequest<A>,
-	db: AccountableDB,
+	db: PlatformDB,
 	...args: A
 ): Promise<RawServerResponse> {
 	const opts: RequestOpts = { baseUrl: db.url.href, credentials: "include" };

--- a/src/transport/errors/PlatformError.ts
+++ b/src/transport/errors/PlatformError.ts
@@ -1,7 +1,7 @@
 import { t } from "../../i18n";
 import { UnreachableCaseError } from "./UnreachableCaseError.js";
 
-export type AccountableErrorCode =
+export type PlatformErrorCode =
 	| "auth/account-already-exists"
 	| "auth/internal-error"
 	| "auth/invalid-argument"
@@ -21,7 +21,7 @@ export type AccountableErrorCode =
 	| "storage/server-file-wrong-size"
 	| "storage/unauthenticated";
 
-function messageFromCode(code: AccountableErrorCode): string {
+function messageFromCode(code: PlatformErrorCode): string {
 	switch (code) {
 		case "auth/account-already-exists":
 			return t("error.auth.account-already-exists");
@@ -60,12 +60,12 @@ function messageFromCode(code: AccountableErrorCode): string {
 	}
 }
 
-export class AccountableError extends Error {
-	readonly code: AccountableErrorCode;
+export class PlatformError extends Error {
+	readonly code: PlatformErrorCode;
 	customData?: Record<string, unknown> | undefined;
-	readonly name = "AccountableError";
+	readonly name = "PlatformError";
 
-	constructor(code: AccountableErrorCode, customData?: Record<string, unknown> | undefined) {
+	constructor(code: PlatformErrorCode, customData?: Record<string, unknown> | undefined) {
 		super(messageFromCode(code));
 		this.code = code;
 		this.customData = customData;

--- a/src/transport/errors/index.ts
+++ b/src/transport/errors/index.ts
@@ -1,5 +1,5 @@
-export * from "./AccountableError.js";
 export * from "./NetworkError.js";
 export * from "./NotImplementedError.js";
+export * from "./PlatformError.js";
 export * from "./UnexpectedResponseError.js";
 export * from "./UnreachableCaseError.js";

--- a/src/transport/onSnapshot.ts
+++ b/src/transport/onSnapshot.ts
@@ -3,12 +3,12 @@ import type { DocumentData } from "./schemas.js";
 import type { Infer } from "superstruct";
 import type { ListenerParameters } from "pubnub";
 import { documentData } from "./schemas.js";
-import { AccountableError, UnexpectedResponseError, UnreachableCaseError } from "./errors/index.js";
 import { databaseCollection, databaseDocument } from "./apiStruts";
 import { doc as docRef, getDoc, getDocs } from "./db.js";
 import { isArray } from "../helpers/isArray.js";
 import { isString } from "../helpers/isString.js";
 import { logger } from "../logger.js";
+import { PlatformError, UnexpectedResponseError, UnreachableCaseError } from "./errors/index.js";
 import { t } from "../i18n.js";
 import { WebSocketCode } from "./websockets/WebSocketCode.js";
 import { wsFactory } from "./websockets/websockets.js";
@@ -328,7 +328,7 @@ export function onSnapshot<T>(
 		onErrorCallback = onError ?? ((err): void => logger.error(err));
 	}
 
-	if (!db.currentUser) throw new AccountableError("database/unauthenticated");
+	if (!db.currentUser) throw new PlatformError("database/unauthenticated");
 
 	let previousSnap: QuerySnapshot<T> | null = null;
 	async function handleData({ data, shouldFetch = false }: WatcherData): Promise<void> {
@@ -431,7 +431,7 @@ export function onSnapshot<T>(
 					return;
 				}
 
-				// Make sure the publisher claims to be Accountable's server. (Only holds back kid hackers with our keys)
+				// Make sure the publisher claims to be our server. (Only holds back kid hackers with our keys)
 				const serverPublisher = "server";
 				if (event.publisher !== serverPublisher) {
 					logger.debug(

--- a/src/transport/server.ts
+++ b/src/transport/server.ts
@@ -1,4 +1,4 @@
-import type { AccountableDB } from "./db";
+import type { PlatformDB } from "./db";
 import { run } from "./apiStruts";
 import { t } from "../i18n";
 import { UnexpectedResponseError } from "./errors";
@@ -9,7 +9,7 @@ import { version as getVersion } from "./api";
  *
  * @returns The server's reported version string.
  */
-export async function getServerVersion(db: AccountableDB): Promise<string> {
+export async function getServerVersion(db: PlatformDB): Promise<string> {
 	const response = await run(getVersion, db);
 	if (response.version === undefined || !response.version)
 		throw new UnexpectedResponseError(t("error.server.no-version"));

--- a/src/transport/storage.ts
+++ b/src/transport/storage.ts
@@ -1,7 +1,7 @@
-import type { AccountableDB, DocumentReference } from "./db";
+import type { PlatformDB, DocumentReference } from "./db";
 import type { AttachmentRecordPackage } from "./attachments";
-import { AccountableError } from "./errors/index.js";
 import { assertFileData } from "./schemas";
+import { PlatformError } from "./errors/index.js";
 import { run } from "./apiStruts";
 import {
 	deleteV0DbUsersByUidAttachmentsAndDocBlobKey,
@@ -10,14 +10,14 @@ import {
 } from "./api";
 
 /**
- * Represents a reference to an Accountable Storage object. Developers can
+ * Represents a reference to a large-storage database object. Developers can
  * upload, download, and delete objects, as well as get/set object metadata.
  */
 export interface StorageReference {
 	/**
-	 * The {@link AccountableDB} instance associated with this reference.
+	 * The {@link PlatformDB} instance associated with this reference.
 	 */
-	readonly db: AccountableDB;
+	readonly db: PlatformDB;
 
 	/**
 	 * The ID of the user which owns the storage object.
@@ -38,13 +38,13 @@ export interface StorageReference {
 
 /**
  * Returns a {@link StorageReference} for the given url.
- * @param db - {@link AccountableDB} instance.
+ * @param db - {@link PlatformDB} instance.
  * @param uid - The ID of the user that owns the reference.
  * @param docRef - A reference to the document that owns the reference.
  * @param name - The file name.
  */
 export function ref(
-	db: AccountableDB,
+	db: PlatformDB,
 	uid: string,
 	docRef: DocumentReference<AttachmentRecordPackage>,
 	name: string
@@ -56,15 +56,14 @@ export function ref(
  * Downloads a string from this object's location.
  * @param ref - {@link StorageReference} where string should exist.
  *
- * @throws an {@link AccountableError} if there was a problem, including
+ * @throws an {@link PlatformError} if there was a problem, including
  * 	if the file was not found.
  * @returns The stored string.
  */
 export async function downloadString(ref: StorageReference): Promise<string> {
 	const uid = ref.db.currentUser?.uid;
-	if (uid === undefined || !uid) throw new AccountableError("storage/unauthenticated");
-	if (ref.docRef.parent.id !== "attachments")
-		throw new AccountableError("storage/invalid-argument");
+	if (uid === undefined || !uid) throw new PlatformError("storage/unauthenticated");
+	if (ref.docRef.parent.id !== "attachments") throw new PlatformError("storage/invalid-argument");
 
 	const { data } = await run(
 		getV0DbUsersByUidAttachmentsAndDocBlobKey,
@@ -85,7 +84,7 @@ export async function downloadString(ref: StorageReference): Promise<string> {
  */
 export async function uploadString(ref: StorageReference, value: string): Promise<void> {
 	const uid = ref.db.currentUser?.uid;
-	if (uid === undefined || !uid) throw new AccountableError("storage/unauthenticated");
+	if (uid === undefined || !uid) throw new PlatformError("storage/unauthenticated");
 
 	const file = new File([value], "file.json", { type: "application/json" });
 
@@ -119,7 +118,7 @@ export async function uploadString(ref: StorageReference, value: string): Promis
  */
 export async function deleteObject(ref: StorageReference): Promise<void> {
 	const uid = ref.db.currentUser?.uid;
-	if (uid === undefined || !uid) throw new AccountableError("storage/unauthenticated");
+	if (uid === undefined || !uid) throw new PlatformError("storage/unauthenticated");
 
 	const { usedSpace, totalSpace } = await run(
 		deleteV0DbUsersByUidAttachmentsAndDocBlobKey,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
 		// See https://github.com/ElMassimo/vite-plugin-environment#usage-with-default-values
 		env(
 			{
-				VITE_ACCOUNTABLE_SERVER_URL: null, // optional
+				VITE_PLATFORM_SERVER_URL: null, // optional
 				VITE_PUBNUB_SUBSCRIBE_KEY: null, // optional
 				VITE_ENABLE_LOGIN: "true",
 				VITE_ENABLE_SIGNUP: "false",


### PR DESCRIPTION
In an effort to prepare for public release, I've found what I hope is a permanent name for this project: _Recorded Finance_.

This PR removes most hard-coded references to the "Accountable" name, and either replaces them with "Recorded Finance" or a central variable that currently contains "Recorded Finance." Future renames, if any, should be much easier, especially where translations are concerned.